### PR TITLE
Validation config missing field

### DIFF
--- a/json_schema_tool/schema.py
+++ b/json_schema_tool/schema.py
@@ -1,5 +1,4 @@
-from json_schema_tool.types import JsonType, JsonValue
-from .types import from_typename, JsonType, from_instance, values_are_equal, JsonTypes, ALL_JSON_TYPES
+from .types import from_typename, JsonValue, from_instance, values_are_equal, JsonTypes, ALL_JSON_TYPES
 from .pointer import JsonPointer
 
 from typing import Dict, List, Optional, Set, Callable, Pattern, Tuple

--- a/json_schema_tool/schema.py
+++ b/json_schema_tool/schema.py
@@ -18,6 +18,7 @@ class ValidationConfig:
     preprocessor: Optional[Callable] = None
     short_circuit_evaluation: bool = False
     strict_content_encoding = False
+    raise_on_unknown_keyword = False
 
 
 @dataclass


### PR DESCRIPTION
When initializing a validator like so:

```python
parse_schema(
    somejson,
    schema.ValidationConfig(short_circuit_evaluation=True)
)
```

I ran into:

```
AttributeError: 'ValidationConfig' object has no attribute 'raise_on_unknown_keyword'
```

It seems a field was missing. 1dbc433 adds it.